### PR TITLE
Fixes #7: msgpack deserialization broken

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,6 @@
          ; and removes "Transfer-Encoding": "chunked".
          :adapter {:output-buffer-size 100}}
   :main kbrowse.core
-  :aot [kbrowse.msgpack]
   :profiles {:uberjar {:aot :all}}
   :test-selectors {:default (complement :integration)
                    :integration :integration})

--- a/run-integration-tests
+++ b/run-integration-tests
@@ -150,6 +150,14 @@ assert 'v2' == json.loads("""$OUTPUT""")[1]['value']
 EOF
 
 
+echo testing-msgpack
+OUTPUT=$(./lein run cli --bootstrap-servers localhost:9092 --topics topic-a --value-deserializer "kbrowse.msgpack.MsgpackDeserializer")
+python <<EOF
+import json
+assert 118 == json.loads("""$OUTPUT""")[1]['value']
+EOF
+
+
 echo
 echo Running web console tests
 node test-console.js

--- a/src/kbrowse/kafka.clj
+++ b/src/kbrowse/kafka.clj
@@ -17,7 +17,11 @@
 (ns kbrowse.kafka
   "Wrap the Java client."
   (:require [clojure.string :as string]
-            [kbrowse.config :as config])
+            [kbrowse.config :as config]
+            ; Ensure msgpack is loaded.
+            ; It's not required initially, but may be passed in as a
+            ; deserializer to be used when instantiating a consumer.
+            [kbrowse.msgpack])
   (:import java.util.ArrayList
            org.apache.kafka.clients.consumer.ConsumerConfig
            org.apache.kafka.clients.consumer.KafkaConsumer


### PR DESCRIPTION
The msgpack classes weren't being loaded, as they weren't
required by any of the namespaces that were being loaded.

Previously, it was thought that adding kbrowse.msgpack as an :aot
in the project configuration would resolve, but this was not the
case, and so has been removed.

This also adds an integration test that fails w/o the fix.