### PR TITLE
Fixes #11: run-integration-tests shutdown

### DIFF
--- a/run-integration-tests
+++ b/run-integration-tests
@@ -50,7 +50,7 @@ function _stop {
 
     exit $EXITING_CODE
 }
-trap _stop SIGINT SIGKILL SIGTERM TERM
+trap _stop EXIT SIGINT SIGKILL SIGTERM TERM
 
 
 # Because it's a local cluster, we can use a low timeout,
@@ -153,6 +153,3 @@ EOF
 echo
 echo Running web console tests
 node test-console.js
-
-
-_stop


### PR DESCRIPTION
This traps the EXIT signal, to ensure that we shutdown child processes
if exiting with an error.  It also removes the explicit _stop call,
which is now handled automatically on EXIT.