### PR TITLE
Fixes #19: use to-map/str in result?

### DIFF
--- a/src/kbrowse/search.clj
+++ b/src/kbrowse/search.clj
@@ -31,12 +31,6 @@
    so that every real result can safely prepend a comma."
   (cheshire/generate-string {:type :pioneer}))
 
-(defn result?
-  "Does this record match the given query params?"
-  [key-regex val-regex record]
-  (and (or (nil? key-regex) (re-matches key-regex (.key record)))
-       (or (nil? val-regex) (re-matches val-regex (.value record)))))
-
 (defn to-map
   "Convert a kafka record object."
   [record]
@@ -59,6 +53,15 @@
         (cheshire/generate-string {:pretty true}))
     (catch Exception e
       (cheshire/generate-string map* {:pretty true}))))
+
+(defn result?
+  "Does this record match the given query params?"
+  [key-regex val-regex record]
+  (let [record-map (to-map record)
+        key-str (str (:key record-map))
+        value-str (str (:value record-map))]
+    (and (or (nil? key-regex) (re-matches key-regex key-str))
+         (or (nil? val-regex) (re-matches val-regex value-str)))))
 
 (defn progress-message
   "Format the progress message for client consumption."


### PR DESCRIPTION
Avro deserialization with search was resulting in an exception:
```
 :cause org.apache.avro.generic.GenericData$Record cannot be cast to java.lang.CharSequence
 :via
 [{:type java.lang.ClassCastException
   :message org.apache.avro.generic.GenericData$Record cannot be cast to java.lang.CharSequence
   :at [clojure.core$re_matcher invokeStatic core.clj 4789]}]
```

This fix is to use a combination of to-map and str to more safely
convert the record for use with re-matches.

----
Test Plan

As described in #20, there are no CI tests for Avro atm.

This uses a similar manual test (including a non-empty valRegex):
```
./bin/confluent start schema-registry

./bin/kafka-topics --zookeeper localhost:2181 --create --topic kbrowse-avro --partitions 10 --replication-factor 1

echo '"k"','{"label": "v"}' | ./bin/kafka-avro-console-producer \
    --broker-list localhost:9092 \
    --topic kbrowse-avro \
    --property parse.key=true \
    --property key.separator=, \
    --property key.schema='{"type": "string", "name": "label"}' \
    --property value.schema='{"type": "record", "name": "value", "fields": [{"type": "string", "name": "label"}]}'

CONFIG=config/default-with-avro.yml ./lein run server

http://localhost:4000/?{%22key%22:%22%22,%22valRegex%22:%22.*%22,%22bootstrapServers%22:%22localhost:9092%22,%22topic%22:%22kbrowse-avro%22,%22relativeOffset%22:%22%22,%22follow%22:false,%22defaultPartition%22:false,%22valueDeserializer%22:%22io.confluent.kafka.serializers.KafkaAvroDeserializer%22,%22schemaRegistryURL%22:%22http://localhost:8081%22,%22partitions%22:%22%22}
```