### PR TITLE
Update to include minimum supported Kafka version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ This design is intended to support copy/paste-able URLs, so folks can share thei
 
 Some browsers may have a limit on the window location length, which could lead to a corrupt state.  This trade-off is accepted, to allow for share-able contexts.
 
+# Kafka Version Compatibility
+Kafka 0.9.0.1+
+
 # Browser Support
 The web console uses Mozilla's Fetch API, and ES6 keywords such as `let` and `const`.
 


### PR DESCRIPTION
Was not able to get kbrowse working on an old 0.8.x cluster, but after upgrading to 0.9.0.1, it works.

I tested (originally) with Confluent 4, but haven't tested w v4 (Kafka 2.0) so leaving this open-ended with a +.