### PR TITLE
Upgrade to Kafka 2.x

### DIFF
--- a/fetch-kafka-tgz
+++ b/fetch-kafka-tgz
@@ -48,9 +48,11 @@ function verify_md5_hash {
     fi
 }
 
-TGZ=kafka_2.11-2.1.0.tgz
+TGZ=kafka_2.12-2.2.1.tgz
 if [ ! -f $TGZ ]; then
     echo Downloading Kafka...
-    curl http://www-us.apache.org/dist/kafka/2.1.0/$TGZ -o $TGZ
-    verify_md5_hash $TGZ 3ee55cd897f12c637abb40b2a78e8fe9
+    curl -L http://www-us.apache.org/dist/kafka/2.2.1/$TGZ -o $TGZ
 fi
+
+# Always verify, in case of re-runs
+verify_md5_hash $TGZ 7b2d2f789fdc93a130880b2a24db6b46

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [compojure "1.6.0"]
                  [io.confluent/kafka-avro-serializer "4.0.0"]
                  [org.apache.avro/avro "1.8.2"]
-                 [org.apache.kafka/kafka_2.11 "1.1.0" :exclusions [log4j org.slf4j/slf4j-log4j12]]
+                 [org.apache.kafka/kafka_2.11 "2.2.1" :exclusions [log4j org.slf4j/slf4j-log4j12]]
                  [org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/tools.logging "0.4.0"]

--- a/src/kbrowse/kafka.clj
+++ b/src/kbrowse/kafka.clj
@@ -89,7 +89,7 @@
 (defn consume
   "Fetch a batch of messages."
   [consumer]
-  (.poll consumer config/kafka-timeout))
+  (.poll consumer (java.time.Duration/ofMillis config/kafka-timeout)))
 
 (defn seek-to-beginning
   "Set the consumer to the beginning of its assigned topic partitions."


### PR DESCRIPTION
Tested against Kafka 1.x within Pandora to confirm backwards compatibility.

Only real change was updating KafkaConsumer.poll to non-Deprecated signature.