### PR TITLE
jdk-11 compatibility

### DIFF
--- a/lein
+++ b/lein
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # This script comes from:
-#   https://raw.githubusercontent.com/technomancy/leiningen/2.6.1/bin/lein
+#   https://raw.githubusercontent.com/technomancy/leiningen/2.9.1/bin/lein
 #
 # License Info:
-#   https://raw.githubusercontent.com/technomancy/leiningen/2.6.1/COPYING
+#   https://raw.githubusercontent.com/technomancy/leiningen/2.9.1/COPYING
 #
 # The only modifications are this comment block!
 
@@ -12,12 +12,23 @@
 # somewhere on your $PATH, like ~/bin. The rest of Leiningen will be
 # installed upon first run into the ~/.lein/self-installs directory.
 
-export LEIN_VERSION="2.6.1"
+function msg {
+    echo "$@" 1>&2
+}
+
+export LEIN_VERSION="2.9.1"
 
 case $LEIN_VERSION in
     *SNAPSHOT) SNAPSHOT="YES" ;;
     *) SNAPSHOT="NO" ;;
 esac
+
+if [[ "$CLASSPATH" != "" ]]; then
+    cat <<-'EOS' 1>&2
+	WARNING: You have $CLASSPATH set, probably by accident.
+	It is strongly recommended to unset this before proceeding.
+	EOS
+fi
 
 if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     delimiter=";"
@@ -32,7 +43,7 @@ else
 fi
 
 function command_not_found {
-    >&2 echo "Leiningen coundn't find $1 in your \$PATH ($PATH), which is required."
+    msg "Leiningen couldn't find $1 in your \$PATH ($PATH), which is required."
     exit 1
 }
 
@@ -63,20 +74,24 @@ function add_path {
 }
 
 function download_failed_message {
-    echo "Failed to download $1 (exit code $2)"
-    echo "It's possible your HTTP client's certificate store does not have the"
-    echo "correct certificate authority needed. This is often caused by an"
-    echo "out-of-date version of libssl. It's also possible that you're behind a"
-    echo "firewall and haven't set HTTP_PROXY and HTTPS_PROXY."
+    cat <<-EOS 1>&2
+	Failed to download $1 (exit code $2)
+	It's possible your HTTP client's certificate store does not have the
+	correct certificate authority needed. This is often caused by an
+	out-of-date version of libssl. It's also possible that you're behind a
+	firewall and haven't set HTTP_PROXY and HTTPS_PROXY.
+	EOS
 }
 
 function self_install {
   if [ -r "$LEIN_JAR" ]; then
-    echo "The self-install jar already exists at $LEIN_JAR."
-    echo "If you wish to re-download, delete it and rerun \"$0 self-install\"."
+    cat <<-EOS 1>&2
+	The self-install jar already exists at $LEIN_JAR.
+	If you wish to re-download, delete it and rerun "$0 self-install".
+	EOS
     exit 1
   fi
-  echo "Downloading Leiningen to $LEIN_JAR now..."
+  msg "Downloading Leiningen to $LEIN_JAR now..."
   mkdir -p "$(dirname "$LEIN_JAR")"
   LEIN_URL="https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip"
   $HTTP_CLIENT "$LEIN_JAR.pending" "$LEIN_URL"
@@ -90,25 +105,6 @@ function self_install {
       exit 1
   fi
 }
-
-function check_root {
-  local -i user_id
-  # Thank you for the complexity, Solaris
-  if [ `uname` = "SunOS" -a -x /usr/xpg4/bin/id ]; then
-    user_id=$(/usr/xpg4/bin/id -u 2>/dev/null || echo 0)
-  else
-    user_id=$(id -u 2>/dev/null || echo 0)
-  fi
-  [ $user_id -eq 0 -a "$LEIN_ROOT" = "" ] && return 0
-  return 1
-}
-
-if check_root; then
-    echo "WARNING: You're currently running as root; probably by accident."
-    echo "Press control-C to abort or Enter to continue as root."
-    echo "Set LEIN_ROOT to disable this warning."
-    read _
-fi
 
 NOT_FOUND=1
 ORIGINAL_PWD="$PWD"
@@ -158,7 +154,7 @@ done
 
 BIN_DIR="$(dirname "$SCRIPT")"
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
 
 # This needs to be defined before we call HTTP_CLIENT below
 if [ "$HTTP_CLIENT" = "" ]; then
@@ -179,13 +175,15 @@ grep -E -q '^\s*:eval-in\s+:classloader\s*$' project.clj 2> /dev/null && \
 
 if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
     # Running from source checkout
-    LEIN_DIR="$(dirname "$BIN_DIR")"
+    LEIN_DIR="$(cd $(dirname "$BIN_DIR");pwd -P)"
 
     # Need to use lein release to bootstrap the leiningen-core library (for aether)
     if [ ! -r "$LEIN_DIR/leiningen-core/.lein-bootstrap" ]; then
-        echo "Leiningen is missing its dependencies."
-        echo "Please run \"lein bootstrap\" in the leiningen-core/ directory"
-        echo "with a stable release of Leiningen. See CONTRIBUTING.md for details."
+        cat <<-'EOS' 1>&2
+	Leiningen is missing its dependencies.
+	Please run "lein bootstrap" in the leiningen-core/ directory
+	with a stable release of Leiningen. See CONTRIBUTING.md for details.
+	EOS
         exit 1
     fi
 
@@ -200,14 +198,13 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
 
     # Use bin/lein to calculate its own classpath.
     if [ ! -r "$LEIN_DIR/.lein-classpath" ] && [ "$1" != "classpath" ]; then
-        echo "Recalculating Leiningen's classpath."
-        ORIG_PWD="$PWD"
+        msg "Recalculating Leiningen's classpath."
         cd "$LEIN_DIR"
 
-        LEIN_NO_USER_PROFILES=1 $0 classpath .lein-classpath
+        LEIN_NO_USER_PROFILES=1 "$LEIN_DIR/bin/lein" classpath .lein-classpath
         sum "$LEIN_DIR/project.clj" "$LEIN_DIR/leiningen-core/project.clj" > \
             .lein-project-checksum
-        cd "$ORIG_PWD"
+        cd -
     fi
 
     mkdir -p "$LEIN_DIR/target/classes"
@@ -223,7 +220,9 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
 else # Not running from a checkout
     add_path CLASSPATH "$LEIN_JAR"
 
-    BOOTCLASSPATH="-Xbootclasspath/a:$LEIN_JAR"
+    if [ "$LEIN_USE_BOOTCLASSPATH" != "no" ]; then
+        LEIN_JVM_OPTS="-Xbootclasspath/a:$LEIN_JAR $LEIN_JVM_OPTS"
+    fi
 
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         self_install
@@ -232,8 +231,8 @@ fi
 
 if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
 then
-    >&2 echo "Leiningen coundn't find 'java' executable, which is required."
-    >&2 echo "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
+    msg "Leiningen couldn't find 'java' executable, which is required."
+    msg "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
     exit 1
 fi
 
@@ -265,24 +264,28 @@ fi
 # you need to remove the self-install and upgrade functionality or see lein-pkg.
 if [ "$1" = "self-install" ]; then
     if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
-        echo "Running self-install from a checkout is not supported."
-        echo "See CONTRIBUTING.md for SNAPSHOT-specific build instructions."
+        cat <<-'EOS' 1>&2
+	Running self-install from a checkout is not supported.
+	See CONTRIBUTING.md for SNAPSHOT-specific build instructions.
+	EOS
         exit 1
     fi
-    echo "Manual self-install is deprecated; it will run automatically when necessary."
+    msg "Manual self-install is deprecated; it will run automatically when necessary."
     self_install
 elif [ "$1" = "upgrade" ] || [ "$1" = "downgrade" ]; then
     if [ "$LEIN_DIR" != "" ]; then
-        echo "The upgrade task is not meant to be run from a checkout."
+        msg "The upgrade task is not meant to be run from a checkout."
         exit 1
     fi
     if [ $SNAPSHOT = "YES" ]; then
-        echo "The upgrade task is only meant for stable releases."
-        echo "See the \"Bootstrapping\" section of CONTRIBUTING.md."
+        cat <<-'EOS' 1>&2
+	The upgrade task is only meant for stable releases.
+	See the "Bootstrapping" section of CONTRIBUTING.md.
+	EOS
         exit 1
     fi
     if [ ! -w "$SCRIPT" ]; then
-        echo "You do not have permission to upgrade the installation in $SCRIPT"
+        msg "You do not have permission to upgrade the installation in $SCRIPT"
         exit 1
     else
         TARGET_VERSION="${2:-stable}"
@@ -292,8 +295,8 @@ elif [ "$1" = "upgrade" ] || [ "$1" = "downgrade" ]; then
         case "$RESP" in
             y|Y|"")
                 echo
-                echo "Upgrading..."
-                TARGET="/tmp/lein-$$-upgrade"
+                msg "Upgrading..."
+                TARGET="/tmp/lein-${$}-upgrade"
                 if $cygwin; then
                     TARGET=$(cygpath -w "$TARGET")
                 fi
@@ -302,15 +305,16 @@ elif [ "$1" = "upgrade" ] || [ "$1" = "downgrade" ]; then
                 if [ $? == 0 ]; then
                     cmp -s "$TARGET" "$SCRIPT"
                     if [ $? == 0 ]; then
-                        echo "Leiningen is already up-to-date."
+                        msg "Leiningen is already up-to-date."
                     fi
                     mv "$TARGET" "$SCRIPT" && chmod +x "$SCRIPT"
+                    unset CLASSPATH
                     exec "$SCRIPT" version
                 else
                     download_failed_message "$LEIN_SCRIPT_URL"
                 fi;;
             *)
-                echo "Aborted."
+                msg "Aborted."
                 exit 1;;
         esac
     fi
@@ -326,7 +330,7 @@ else
     fi
 
     if [ -n "$DEBUG" ]; then
-        echo "Leiningen's classpath: $CLASSPATH"
+        msg "Leiningen's classpath: $CLASSPATH"
     fi
 
     if [ -r .lein-fast-trampoline ]; then
@@ -344,7 +348,7 @@ else
             command_not_found "sha1sum or shasum"
         fi
 
-        export INPUT_CHECKSUM=$(echo "$INPUTS" | $SUM | cut -f 1 -d " ")
+        INPUT_CHECKSUM=$(echo "$INPUTS" | $SUM | cut -f 1 -d " ")
         # Just don't change :target-path in project.clj, mkay?
         TRAMPOLINE_FILE="target/trampolines/$INPUT_CHECKSUM"
     else
@@ -354,7 +358,7 @@ else
         else
             TRAMPOLINE_FILE="/tmp/lein-trampoline-$$"
         fi
-        trap "rm -f $TRAMPOLINE_FILE" EXIT
+        trap 'rm -f $TRAMPOLINE_FILE' EXIT
     fi
 
     if $cygwin; then
@@ -363,17 +367,17 @@ else
 
     if [ "$INPUT_CHECKSUM" != "" ] && [ -r "$TRAMPOLINE_FILE" ]; then
         if [ -n "$DEBUG" ]; then
-            echo "Fast trampoline with $TRAMPOLINE_FILE."
+            msg "Fast trampoline with $TRAMPOLINE_FILE."
         fi
         exec sh -c "exec $(cat "$TRAMPOLINE_FILE")"
     else
         export TRAMPOLINE_FILE
         "$LEIN_JAVA_CMD" \
-            "${BOOTCLASSPATH[@]}" \
             -Dfile.encoding=UTF-8 \
             -Dmaven.wagon.http.ssl.easy=false \
             -Dmaven.wagon.rto=10000 \
             $LEIN_JVM_OPTS \
+            -Dleiningen.input-checksum="$INPUT_CHECKSUM" \
             -Dleiningen.original.pwd="$ORIGINAL_PWD" \
             -Dleiningen.script="$SCRIPT" \
             -classpath "$CLASSPATH" \
@@ -385,11 +389,9 @@ else
           stty icanon echo > /dev/null 2>&1
         fi
 
-        ## TODO: [ -r "$TRAMPOLINE_FILE" ] may be redundant? A trampoline file
-        ## is always generated these days.
         if [ -r "$TRAMPOLINE_FILE" ] && [ "$LEIN_TRAMPOLINE_WARMUP" = "" ]; then
             TRAMPOLINE="$(cat "$TRAMPOLINE_FILE")"
-            if [ "$INPUT_CHECKSUM" = "" ]; then
+            if [ "$INPUT_CHECKSUM" = "" ]; then # not using fast trampoline
                 rm "$TRAMPOLINE_FILE"
             fi
             if [ "$TRAMPOLINE" = "" ]; then

--- a/project.clj
+++ b/project.clj
@@ -30,8 +30,8 @@
                  [org.clojure/tools.logging "0.4.0"]
                  [ring/ring-core "1.6.3" :exclusions [commons-codec]]
                  [ring/ring-jetty-adapter "1.6.3"]]
-  :repositories {"central" "http://central.maven.org/maven2/"
-                 "confluent" "http://packages.confluent.io/maven/"}
+  :repositories {"central" "https://repo1.maven.org/maven2/"
+                 "confluent" "https://packages.confluent.io/maven/"}
   :plugins [[lein-ring "0.12.4" :exclusions [org.clojure/clojure]]
             [lein-cljfmt "0.5.7"]]
   :ring {:handler kbrowse.core/app


### PR DESCRIPTION
Travis CI defaults to Java 11 now, so this updates for compatibility:
  - upgrade Leiningen to version that works with Java 11
  - update maven deps to TLS versions