### PR TITLE
Fixes #39: Topics stop refreshing

### DIFF
--- a/fetch-kafka-tgz
+++ b/fetch-kafka-tgz
@@ -48,11 +48,11 @@ function verify_md5_hash {
     fi
 }
 
-TGZ=kafka_2.12-2.2.1.tgz
+TGZ=kafka_2.12-2.7.0.tgz
 if [ ! -f $TGZ ]; then
     echo Downloading Kafka...
-    curl -L http://www-us.apache.org/dist/kafka/2.2.1/$TGZ -o $TGZ
+    curl -L http://www-us.apache.org/dist/kafka/2.7.0/$TGZ -o $TGZ
 fi
 
 # Always verify, in case of re-runs
-verify_md5_hash $TGZ 7b2d2f789fdc93a130880b2a24db6b46
+verify_md5_hash $TGZ 9127875811b8a7b7a5b84d0c4c19874b

--- a/src/kbrowse/topics.clj
+++ b/src/kbrowse/topics.clj
@@ -47,5 +47,5 @@
             (Thread/sleep (* config/kafka-topics-cache-sleep-seconds 1000))
             (try
               (refresh)
-            (catch Exception e
-              (println "topics/refresh exception - topics may become stale" e))))))
+              (catch Exception e
+                (println "topics/refresh exception - topics may become stale" e))))))

--- a/src/kbrowse/topics.clj
+++ b/src/kbrowse/topics.clj
@@ -45,4 +45,7 @@
   ; Keep updating in background
   (future (while true
             (Thread/sleep (* config/kafka-topics-cache-sleep-seconds 1000))
-            (refresh))))
+            (try
+              (refresh)
+            (catch Exception e
+              (println "topics/refresh exception - topics may become stale" e))))))


### PR DESCRIPTION
#### Background
During initialization, kbrowse starts a separate thread that intermittenly
refreshes the topics lists from the kafka brokers.

If an exception was thrown during a refresh, the thread died,
and topics would stop refreshing.

This could happen if a cluster were down for long enough to trigger a
timeout exception, for example.

#### Fix
This adds exception handling around the refresh call.

If we catch an exception, we log it, but continue on.

#### Test Plan
1. Start Kafka/Zookeeper:
```
./run-zookeeper-and-kafka
```

2. Start kbrowse:
```
KAFKA_TOPICS_CACHE_SLEEP_SECONDS=5 ./lein run server
```

3. Ctrl-C Kafka/Zookeeper

4. Wait for kbrowse timeout to log

5. Restart Kafka/Zookeeper

6. Create new topic:
```
./kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic kbrowse-2 --partitions 10 --replication-factor 1
```

7. Verify that the new topic shows up in running kbrowse:
```
http://localhost:4000
```